### PR TITLE
Fix vlines plotting bug

### DIFF
--- a/ForensikVideo.py
+++ b/ForensikVideo.py
@@ -435,10 +435,12 @@ def create_plots(frames: list[FrameInfo], out_dir: Path, video_name: str) -> dic
             color_map = {"duplication": 'orange', "insertion": 'red', "discontinuity": 'purple', "deletion_event": "blue"}
             colors.append(color_map.get(f.type.split('_')[-1], 'black'))
         else:
-            labels.append(0); colors.append('green')
-            
-    plt.vlines(indices[labels], ymin=0, ymax=[l for l in labels if l > 0], colors=[c for c, l in zip(colors, labels) if l > 0], lw=2)
-    plt.scatter(indices[labels], [l for l in labels if l>0], c=[c for c,l in zip(colors, labels) if l>0])
+            labels.append(0)
+            colors.append('green')
+
+    mask = np.array(labels, dtype=bool)
+    plt.vlines(indices[mask], ymin=0, ymax=np.ones(mask.sum()), colors=np.array(colors)[mask], lw=2)
+    plt.scatter(indices[mask], np.ones(mask.sum()), c=np.array(colors)[mask])
     plt.ylim(-0.1, 1.1); plt.xlabel("Indeks Bingkai"); plt.ylabel("Anomali (1=Ya, 0=Tidak)")
     plt.title(f"Peta Anomali Temporal untuk {video_name}"); plt.grid(True, axis='x', linestyle='--', alpha=0.6)
 


### PR DESCRIPTION
## Summary
- fix mismatched array lengths when plotting anomaly timeline

## Testing
- `python - <<'PY'
import ForensikVideo as fv
from pathlib import Path
frames=[fv.FrameInfo(index=i,timestamp=i/15,img_path=str(i)+'.jpg',type=('anomaly_insertion' if i%3==0 else 'original')) for i in range(10)]
for f in frames:
 open(f.img_path,'wb').close()
fv.create_plots(frames, Path('.'), 'testvideo')
print('done')
PY`


------
https://chatgpt.com/codex/tasks/task_b_685141421398832c9c23271613c2517f